### PR TITLE
Occasionally recycle Postgres source connections

### DIFF
--- a/lib/postgres_to_redshift.rb
+++ b/lib/postgres_to_redshift.rb
@@ -112,6 +112,7 @@ class PostgresToRedshift
       zip.finish
       tmpfile.rewind
       upload_table(table, tmpfile, chunk)
+      source_connection.reset
     ensure
       zip.close unless zip.closed?
       tmpfile.unlink


### PR DESCRIPTION
As mentioned in #16, I try reopening fresh connections with this change after uploading a file to S3.  It is a useful change, since uploading a file could take a while, and the connection could become stale.  I've found it makes the script progress further with the larger tables, but the same error will still happen.

According to the documentation for [PG::Connection](https://deveiate.org/code/pg/PG/Connection.html), the `reset` method:

> Resets the backend connection. This method closes the backend connection and tries to re-connect.)

This fix is a stopgap for some large tables, but the code will need a refactor to successfully handle really large tables.