### PR TITLE
Support JSONB datatypes and support flexible schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Set your source and target databases, as well as your s3 intermediary.
 ```bash
 export POSTGRES_TO_REDSHIFT_SOURCE_URI='postgres://username:password@host:port/database-name'
 export POSTGRES_TO_REDSHIFT_TARGET_URI='postgres://username:password@host:port/database-name'
+export POSTGRES_TO_REDSHIFT_TARGET_SCHEMA='testing-data'
 export S3_DATABASE_EXPORT_ID='yourid'
 export S3_DATABASE_EXPORT_KEY='yourkey'
 export S3_DATABASE_EXPORT_BUCKET='some-bucket-to-use'

--- a/lib/postgres_to_redshift/column.rb
+++ b/lib/postgres_to_redshift/column.rb
@@ -49,6 +49,7 @@ class PostgresToRedshift::Column
   CAST_TYPES_FOR_COPY = {
     "text" => "CHARACTER VARYING(65535)",
     "json" => "CHARACTER VARYING(65535)",
+    "jsonb" => "CHARACTER VARYING(65535)",
     "bytea" => "CHARACTER VARYING(65535)",
     "money" => "DECIMAL(19,2)",
     "oid" => "CHARACTER VARYING(65535)",


### PR DESCRIPTION
Two thing: Allow JSONB types to be cast just like JSON types and require a `POSTGRES_TO_REDSHIFT_TARGET_SCHEMA` env variable to allow sending the data to a specific schema.